### PR TITLE
Return relayed http response and minor visual status bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ When you start `NetPassage`, it will display a UI in your terminal with the publ
 
 ## Architecture
 
-`NetPassage`uses Microsoft Azure Service Bus Relay to tunnel all incoming
+`NetPassage` uses Microsoft Azure Service Bus Relay to tunnel all incoming
 messages thru the Relay's hybrid connections (either Websocket or Http) and to
-the remotely running (e.g. local) `NetPassage`client utility's listener, as
+the remotely running (e.g. local) `NetPassage` client utility's listener, as
 shown in the architecture diagram below:
 
 ![Architecture](docs/images/passage.png)
@@ -46,7 +46,7 @@ Bus.
 
     d. "PolicyKey" is the secret key value for the shared access policy.
 
-    e. "TargetServiceAddress" sets the port to be used for localhost. The address and port number should match the address and port used by your bot. For example, `http:/localhost:[PORT]`.
+    e. "TargetServiceAddress" sets the port to be used for localhost. The address and port number should match the address and port used by your bot. For example, `http://localhost:[PORT]`.
 
 If you're going to use the `Websocket` relay, you'd also need to update the values in the **appsettings.json** for the `Microsoft.HybridConnections.Relay` project.
 
@@ -63,7 +63,7 @@ Bus.
 
     d. "PolicyKey" is the secret key value for the shared access policy.
 
-    e. "TargetServiceAddress" sets the port to be used for localhost. The address and port number should match the address and port used by your bot. For example, `http:/localhost:[PORT]`.
+    e. "TargetServiceAddress" sets the port to be used for localhost. The address and port number should match the address and port used by your bot. For example, `http://localhost:[PORT]`.
 
 Before testing the relay, your Azure Web Bot's messaging endpoint must be updated to match the relay.
 
@@ -94,6 +94,22 @@ And, if you're planning on using only `Http` mode, you should only run `NetPassa
 
     b. The .exe will output to the **/bin/debug** folder, along with other necessary files, located in the project’s directory folder. All the files are necessary to run and should be included when moving the .exe to a new folder/location.
     - The **app.config** is in the same folder and can be edited as credentials change without needing to recompile the project.
+
+### Building with Visual Studio for Mac
+
+When building the solution on Mac, the steps are largely the same as shown above with a couple things to keep note of:
+
+1. The **appsettings.json** file may not automatically get moved into **/bin** after building by default. It is required, so ensure it is being properly copied over during build if you run into issues.
+
+2. The `NetPassage` default run configuration may not pass in the required configuration file by default. To fix this, ensure "**NetPassage.json**" is being passed into your default Run Configuration.
+
+    a. Right click the project folder in Visual Studio for Mac and select **Options**.
+
+    b. Under **Run**, select the **Default** configuration.
+
+    c. In the **Arguments** field, enter "**NetPassage.json**".
+
+    d. Select **OK** and retry running `NetPassage` via Visual Studio for Mac.
 
 ## Acknowledgments
 

--- a/src/NetPassage/NetPassage.csproj
+++ b/src/NetPassage/NetPassage.csproj
@@ -6,15 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="appsettings.json" />
     <None Remove="NetPassage.json" />
     <None Remove="NetPassage.json.template" />
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
     <Content Include="NetPassage.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/NetPassage/NetPassage.csproj
+++ b/src/NetPassage/NetPassage.csproj
@@ -6,11 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="appsettings.json" />
     <None Remove="NetPassage.json" />
     <None Remove="NetPassage.json.template" />
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="NetPassage.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/NetPassage/Program.cs
+++ b/src/NetPassage/Program.cs
@@ -47,7 +47,7 @@ namespace NetPassage
 
             if (args.Length < 1)
             {
-                ShowError("Missing configuration file");
+                ShowError("Missing configuration file commandline argument");
                 Environment.Exit(0);
             }
 
@@ -91,7 +91,7 @@ namespace NetPassage
                         // maintained, and is reestablished when connectivity is disrupted.
                         Program.KeepRunning = RunHttpRelayAsync(httpRelayListener).GetAwaiter().GetResult();
                     }
-                    else // WebSockets Relay Mode
+                    else // WebSockets Relay Mode 
                     {
                         // Create the WebSockets hybrid proxy listener
                         var webSocketListener = new WebSocketListener(
@@ -169,10 +169,10 @@ namespace NetPassage
                 // Send the request message to the target listener
                 var requestMessage = await HttpListener.CreateHttpRequestMessageAsync(context, ConnectionName);
                 var responseMessage = await SendHttpRequestAsync(requestMessage);
-                Logger.LogRequest(requestMessage.Method.Method, requestMessage.RequestUri.LocalPath, $"\u001b[32m {responseMessage.StatusCode} \u001b[0m", $"Forwarded to {TargetHttpRelay}.", ShowAll);
+                Logger.LogRequest(requestMessage.Method.Method, requestMessage.RequestUri.LocalPath, $"\u001b[32m {responseMessage.StatusCode} \u001b[0m", $"Forwarded to {TargetHttpRelay}", ShowAll);
 
                 // Send the response message back to the caller
-                // await HttpListener.SendResponseAsync(context, responseMessage);
+                await HttpListener.SendResponseAsync(context, responseMessage);
             }
             catch (RelayException re)
             {
@@ -306,7 +306,7 @@ namespace NetPassage
 
         static void ShowConfiguration(IConfiguration config)
         {
-            var relayNamespace = $"sb://{config["Relay:Namespace"]}.servicebus.windows.net";
+            var relayNamespace = $"sb://{config[$"{config["Relay:Mode"]}:Namespace"]}.servicebus.windows.net";
             var IsHttpRelayMode = config["Relay:Mode"].Equals("http", StringComparison.CurrentCultureIgnoreCase);
 
             Console.ForegroundColor = ConsoleColor.White;

--- a/src/NetPassage/Program.cs
+++ b/src/NetPassage/Program.cs
@@ -91,7 +91,7 @@ namespace NetPassage
                         // maintained, and is reestablished when connectivity is disrupted.
                         Program.KeepRunning = RunHttpRelayAsync(httpRelayListener).GetAwaiter().GetResult();
                     }
-                    else // WebSockets Relay Mode 
+                    else // WebSockets Relay Mode
                     {
                         // Create the WebSockets hybrid proxy listener
                         var webSocketListener = new WebSocketListener(
@@ -169,7 +169,7 @@ namespace NetPassage
                 // Send the request message to the target listener
                 var requestMessage = await HttpListener.CreateHttpRequestMessageAsync(context, ConnectionName);
                 var responseMessage = await SendHttpRequestAsync(requestMessage);
-                Logger.LogRequest(requestMessage.Method.Method, requestMessage.RequestUri.LocalPath, $"\u001b[32m {responseMessage.StatusCode} \u001b[0m", $"Forwarded to {TargetHttpRelay}", ShowAll);
+                Logger.LogRequest(requestMessage.Method.Method, requestMessage.RequestUri.LocalPath, $"\u001b[32m {responseMessage.StatusCode} \u001b[0m", $"Forwarded to {TargetHttpRelay}.", ShowAll);
 
                 // Send the response message back to the caller
                 await HttpListener.SendResponseAsync(context, responseMessage);


### PR DESCRIPTION
* Return relayed HTTP response to server
    - I was able to get NetPassage HTTP forwarding working with the .NET Core sample MessagingExtension sample project only when uncommenting a line of code that seemed to be responsible for returning the relayed HTTP response back to the relay server. This PR includes this change
* Visual status bug fix
    - When displaying the forwarding status in the console, the namespace display currently uses `$"sb://{config["Relay:Namespace"]}.servicebus.windows.net";`, which doesn't work with the current `NetPassage.json` template structure (it shows a blank namespace in the console), so this PR updates this to follow the template structure
* README notes on running with Visual Studio for Mac
    - When building and running this on my Mac I ran into some non-obvious issues with differences in how Visual Studio for Mac functions as opposed to the Windows version of Visual Studio -- so I added a couple of notes that I hope could be helpful to any potential Mac users in the future!

I'm open to any and all feedback on these changes of course! Let me know your thoughts. This made it so that I could get it working on my end :)